### PR TITLE
Don't set the slug when creating a new resource without a subject

### DIFF
--- a/lib/ldp/client/methods.rb
+++ b/lib/ldp/client/methods.rb
@@ -24,6 +24,10 @@ module Ldp::Client::Methods
     check_for_errors(resp)
   end
 
+  def endpoint_path
+    @path ||= @http.url_prefix.path
+  end
+
   # Get a LDP Resource by URI
   def get url, options = {}
     logger.debug "LDP: GET [#{url}]"

--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -21,8 +21,8 @@ module Ldp
     # @return [RdfSource] the new representation
     def create
       raise "Can't call create on an existing resource" unless new?
-      resp = client.post '', graph.dump(:ttl) do |req|
-        req.headers['Slug'] = subject
+      resp = client.post client.endpoint_path, graph.dump(:ttl) do |req|
+        req.headers['Slug'] = slug if subject
       end
 
       @subject = resp.headers['Location']
@@ -86,5 +86,11 @@ module Ldp
 
       diff
     end
+
+    private
+
+      def slug
+        subject.sub(/^.+#{client.endpoint_path}\//, '')
+      end
   end
 end

--- a/spec/lib/ldp/orm/orm_spec.rb
+++ b/spec/lib/ldp/orm/orm_spec.rb
@@ -16,7 +16,7 @@ describe Ldp::Orm do
   end
 
   let(:mock_conn) do
-    Faraday.new do |builder|
+    Faraday.new 'http://localhost:8983/fedora/rest' do |builder|
       builder.adapter :test, conn_stubs do |stub|
       end
     end
@@ -40,7 +40,7 @@ describe Ldp::Orm do
   describe "#create" do
     let(:conn_stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post("/") { [201]}
+        stub.post("/fedora/rest") { [201]}
       end
     end
     let :test_resource do

--- a/spec/lib/ldp/resource/rdf_source_spec.rb
+++ b/spec/lib/ldp/resource/rdf_source_spec.rb
@@ -7,13 +7,12 @@ describe Ldp::Resource::RdfSource do
 
   let(:conn_stubs) do
     Faraday::Adapter::Test::Stubs.new do |stub|
-      # stub.get('/a_resource') {[ 200, {"Link" => "http://www.w3.org/ns/ldp#Resource;rel=\"type\""}, simple_graph ]}
-      stub.post("/") { [201]}
+      stub.post("/fedora/rest") { [201]}
     end
   end
 
   let(:mock_conn) do
-    Faraday.new do |builder|
+    Faraday.new 'http://localhost:8983/fedora/rest' do |builder|
       builder.adapter :test, conn_stubs do |stub|
       end
     end


### PR DESCRIPTION
Without this patch I see this error:

```
     NoMethodError:
       undefined method `strip' for nil:NilClass
     # /Users/justin/workspace/ldp/lib/ldp/client/methods.rb:70:in `post'
     # /Users/justin/workspace/ldp/lib/ldp/resource/rdf_source.rb:24:in `create'
     # /Users/justin/workspace/ldp/lib/ldp/orm.rb:43:in `block in create'
     # /Users/justin/workspace/ldp/lib/ldp.rb:32:in `instrument'
     # /Users/justin/workspace/ldp/lib/ldp/orm.rb:40:in `create'
```
