### PR TITLE
Adding Github as homepage

### DIFF
--- a/ldp.gemspec
+++ b/ldp.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["chris@cbeer.info"]
   spec.description   = %q{Linked Data Platform client library}
   spec.summary       = spec.description
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/cbeer/ldp"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
When I'm looking at a gemspec, I can see which gems are used.
To then attempt to find where those gems are defined, I invariably go
to https://rubygems.org/gem/<name_of_gem>. Once there I would like to
see a link to the homepage of that gem. In most cases the Github
repository is adequate.
