### PR TITLE
Adds requirements for Fedora's alpha-6 implementation of LDP.

### DIFF
--- a/lib/ldp/response.rb
+++ b/lib/ldp/response.rb
@@ -113,13 +113,21 @@ module Ldp
     ##
     # Extract the ETag for the resource
     def etag
-      headers['ETag']
+      @etag ||= headers['ETag']
+    end
+
+    def etag=(val)
+      @etag = val
     end
 
     ##
     # Extract the last modified header for the resource
     def last_modified
-      headers['Last-Modified']
+      @last_modified ||= headers['Last-Modified']
+    end
+
+    def last_modified=(val)
+      @last_modified = val
     end
 
     ##

--- a/spec/lib/ldp/resource/rdf_source_spec.rb
+++ b/spec/lib/ldp/resource/rdf_source_spec.rb
@@ -9,7 +9,7 @@ describe Ldp::Resource::RdfSource do
     Faraday::Adapter::Test::Stubs.new do |stub|
       # stub.get('/a_resource') {[ 200, {"Link" => "<http://www.w3.org/ns/ldp#Resource>;rel=\"type\""}, simple_graph ]}
       stub.post("/") { [201]}
-      stub.post("/abs_url_object") { [201]}
+      stub.put("/abs_url_object") { [201]}
     end
   end
 

--- a/spec/lib/ldp/resource_spec.rb
+++ b/spec/lib/ldp/resource_spec.rb
@@ -61,7 +61,7 @@ describe Ldp::Resource do
     context "with initial content" do
       let(:path) { '/a_new_resource' }
       it "should post an RDF graph" do
-        mock_client.should_receive(:post).with(path, "xyz").and_return(double(headers: {}))
+        mock_client.should_receive(:put).with(path, "xyz").and_return(double(headers: {}))
         subject.content = "xyz"
         subject.save
       end


### PR DESCRIPTION
Uses PUT/POST appropriately for creating a new record with an ID.
Updates etag and last-modified in cached response when updating - stops
412 errors on repeated saves.
