### PR TITLE
Don't bother doing a HEAD request to see if the object is new

### DIFF
--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -27,7 +27,17 @@ module Ldp
     end
 
     def graph
-      @graph ||= new? ? build_empty_graph : filtered_graph(response_graph)
+      @graph ||= begin
+                   if subject.nil?
+                     build_empty_graph
+                   else
+                     filtered_graph(response_graph)
+                   end
+                 rescue Ldp::NotFound
+                   # This is an optimization that lets us avoid doing HEAD + GET
+                   # when the object exists. We just need to handle the 404 case
+                   build_empty_graph
+                 end
     end
 
     def build_empty_graph

--- a/spec/lib/ldp/resource/rdf_source_spec.rb
+++ b/spec/lib/ldp/resource/rdf_source_spec.rb
@@ -17,6 +17,7 @@ describe Ldp::Resource::RdfSource do
       stub.post("/") { [201]}
       stub.put("/abs_url_object") { [201]}
       stub.head("/abs_url_object") {[404]}
+      stub.get("/abs_url_object") {[404]}
       stub.head("/existing_object") {[200, {'Content-Type'=>'text/turtle'}]}
       stub.get("/existing_object") {[200, {'Content-Type'=>'text/turtle'}, simple_graph_source]}
     end
@@ -102,7 +103,7 @@ describe Ldp::Resource::RdfSource do
     end
     context 'for an existing object' do
       subject { Ldp::Resource::RdfSource.new mock_client, "http://my.ldp.server/existing_object" }
-      it do 
+      it do
         expect(subject.graph.size).to eql(1)
       end
     end


### PR DESCRIPTION
If it is new, we'll get the data and have avoided a HEAD request.
We just need to handle a 404, when it doesn't exist.

This results in a 27% decrease in HEAD requests in the ActiveFedora
create a work with access controls use case.