### PR TITLE
Response.for requires the third argument.

### DIFF
--- a/lib/ldp/resource.rb
+++ b/lib/ldp/resource.rb
@@ -6,7 +6,7 @@ module Ldp
     attr_reader :client, :subject
     attr_accessor :content
 
-    def self.for(client, subject, response = nil)
+    def self.for(client, subject, response)
       case
       when response.container?
         Ldp::Container.for client, subject, response


### PR DESCRIPTION
Previously it was optional which resulted in a nil pointer error.