### PR TITLE
Update the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 rvm:
-  - 2.4.1
-  - 2.3.4
+  - ruby-head
+  - 2.4
+  - 2.3
+  - 2.2
   - jruby-9.1.8.0
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
The proposed changes are:

  - Build on latest Ruby 2.2, 2.3 and 2.4.
  - Move jruby build to latest.
  - Add build for `ruby-head` with failures allowed.

In addition to this, I propose to add a weekly travis cron job to build `master` against this matrix.