### PR TITLE
Support different forms of the Content-Disposition header

### DIFF
--- a/lib/ldp/response.rb
+++ b/lib/ldp/response.rb
@@ -154,7 +154,7 @@ module Ldp
     # Statements about the page
     def page
       @page_graph ||= begin
-        g = RDF::Graph.new  
+        g = RDF::Graph.new
 
         if resource?
           res = graph.query RDF::Statement.new(page_subject, nil, nil)
@@ -199,11 +199,20 @@ module Ldp
     end
 
     def content_disposition_filename
-      m = headers['Content-Disposition'].match(/filename="(?<filename>[^"]*)";/)
-      URI.decode(m[:filename]) if m
+      filename = content_disposition_attributes['filename']
+      URI.decode(filename) if filename
     end
 
     private
+
+    def content_disposition_attributes
+      parts = headers['Content-Disposition'].split(/;\s*/).collect { |entry| entry.split(/\s*=\s*/) }
+      entries = parts.collect do |part|
+        value = part[1].respond_to?(:sub) ? part[1].sub(%r{^"(.+)"$}, '\1') : part[1]
+        [part[0], value]
+      end
+      Hash[entries]
+    end
 
     def headers
       response.headers

--- a/spec/lib/ldp/response_spec.rb
+++ b/spec/lib/ldp/response_spec.rb
@@ -199,12 +199,14 @@ describe Ldp::Response do
   describe '#content_disposition_filename' do
     before do
       allow(mock_response).to receive(:headers).and_return(
-        'Content-Disposition' => 'filename="xyz.txt";'
+        { 'Content-Disposition' => 'filename="xyz.txt";' },
+        { 'Content-Disposition' => 'attachment; filename=xyz.txt' },
+        { 'Content-Disposition' => 'attachment; filename="xyz.txt"; size="12345"' },
       )
     end
 
     it 'provides the filename from the content disposition header' do
-      expect(subject.content_disposition_filename).to eq 'xyz.txt'
+      3.times { expect(subject.content_disposition_filename).to eq 'xyz.txt' }
     end
   end
 end


### PR DESCRIPTION
`Ldp::Response#content_disposition_filename` currently depends on a very specific form of the `Content-Disposition` header. This PR makes it more flexible. The issue came to light while trying to run [samvera/hyrax](https://github.com/samvera/hyrax) on top of [scossu/lakesuperior](https://github.com/scossu/lakesuperior).