### PR TITLE
show uri when Ldp::Conflict is incountered

### DIFF
--- a/lib/ldp/resource.rb
+++ b/lib/ldp/resource.rb
@@ -79,7 +79,7 @@ module Ldp
     # @return [RdfSource] the new representation
     # @raise [Ldp::Conflict] if you attempt to call create on an existing resource
     def create &block
-      raise Ldp::Conflict, "Can't call create on an existing resource" unless new?
+      raise Ldp::Conflict, "Can't call create on an existing resource (#{subject})" unless new?
       verb = subject.nil? ? :post : :put
       resp = client.send(verb, (subject || @base_path), content) do |req|
         req.headers["Link"] = "<#{interaction_model}>;rel=\"type\"" if interaction_model


### PR DESCRIPTION
Fixes issue #91 by displaying the subject URI along with the Ldp::Conflict error message.Ldp: