### PR TITLE
Upgrades the Travis CI build matrix to use later Ruby/JRuby releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 rvm:
   - ruby-head
-  - 2.4
-  - 2.3
-  - 2.2
-  - jruby-9.1.8.0
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
+  - 2.2.10
+  - jruby-9.2.0.0
+  - jruby-9.1.17.0
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Upgrades the Travis CI build matrix to use Ruby releases 2.5.1, 2.4.4, 2.3.7, and 2.2.10, along with JRuby releases jruby-9.2.0.0 and jruby-9.1.17.0.  Resolves #92 