### PR TITLE
optimize subject filtering

### DIFF
--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -81,20 +81,14 @@ module Ldp
 
       # we want to scope this graph to just statements about this model, not contained relations
       return original_graph if contains_statements.empty?
-
       graph_without_inlined_resources(original_graph, contains_statements.objects)
     end
 
     def graph_without_inlined_resources(original_graph, inlined_resources)
-      new_graph = build_empty_graph
-
-      original_graph.each_statement do |s|
-        unless inlined_resources.include? s.subject
-          new_graph << s
-        end
+      inlined_resources.each do |contained_uri|
+        original_graph.delete(original_graph.query(subject: contained_uri))
       end
-
-      new_graph
+      original_graph
     end
   end
 end

--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -70,7 +70,7 @@ module Ldp
     # @param [Faraday::Response] graph query response
     # @return [RDF::Graph]
     def response_as_graph(resp)
-      build_empty_graph << resp.reader
+      resp.graph
     end
 
     ##

--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -79,15 +79,10 @@ module Ldp
     def filtered_graph(original_graph)
       contains_statements = original_graph.query(predicate: RDF::Vocab::LDP.contains)
 
-      # we want to scope this graph to just statements about this model, not contained relations
-      return original_graph if contains_statements.empty?
-      graph_without_inlined_resources(original_graph, contains_statements.objects)
-    end
-
-    def graph_without_inlined_resources(original_graph, inlined_resources)
-      inlined_resources.each do |contained_uri|
+      contains_statements.each_object do |contained_uri|
         original_graph.delete(original_graph.query(subject: contained_uri))
       end
+
       original_graph
     end
   end

--- a/lib/ldp/response.rb
+++ b/lib/ldp/response.rb
@@ -105,9 +105,7 @@ module Ldp
     # Get the graph for the resource (or a blank graph if there is no metadata for the resource)
     def graph
       @graph ||= begin
-        graph = RDF::Graph.new
-        each_statement { |s| graph << s }
-        graph
+        RDF::Graph.new << reader
       end
     end
 
@@ -115,6 +113,8 @@ module Ldp
       reader_for_content_type.new(body, base_uri: page_subject, &block)
     end
 
+    ##
+    # @deprecated use {#graph} instead
     def each_statement(&block)
       reader do |reader|
         reader.each_statement(&block)
@@ -155,17 +155,9 @@ module Ldp
     # Statements about the page
     def page
       @page_graph ||= begin
-        g = RDF::Graph.new
-
-        if resource?
-          res = graph.query RDF::Statement.new(page_subject, nil, nil)
-
-          res.each_statement do |s|
-            g << s
-          end
-        end
-
-        g
+        page_graph = RDF::Graph.new
+        page_graph << graph.query([page_subject, nil, nil]) if resource?
+        page_graph
       end
     end
 

--- a/spec/lib/ldp/resource/rdf_source_spec.rb
+++ b/spec/lib/ldp/resource/rdf_source_spec.rb
@@ -107,6 +107,24 @@ describe Ldp::Resource::RdfSource do
         expect(subject.graph.size).to eql(1)
       end
     end
+
+    context 'with inlined resources' do
+      subject { Ldp::Resource::RdfSource.new mock_client, "http://my.ldp.server/existing_object" }
+
+      let(:simple_graph) do
+        graph = RDF::Graph.new
+        graph << [RDF::URI.new(), RDF::Vocab::DC.title, "Hello, world!"]
+        graph << [RDF::URI.new(), RDF::Vocab::LDP.contains, contained_uri]
+        graph << [contained_uri, RDF::Vocab::DC.title, "delete me"]
+      end
+
+      let(:contained_uri) { RDF::URI.new('http://example.com/contained') }
+
+      it do
+        expect(subject.graph.subjects)
+          .to contain_exactly(RDF::URI('http://my.ldp.server/existing_object'))
+      end
+    end
   end
 
   context "When graph_class is overridden" do


### PR DESCRIPTION
the older implementation looped over each statement. within those loops it
looped over each inlined resource URI. then it allocated an entirely new graph
and shoveled resources into it.

RDF.rb doesn't have a delete-by-query, but we can do a lot better by: looping
over the inlined resource URIs, doing a query (which is a hash lookup O(1)-ish),
and then using `#delete` (which is also hash-driven) to drop matching
statements. in addition to involving much faster data structure operations, this
should avoid a large number of allocations in the normal case.