### PR TITLE
fix a regression in handling for custom graph classes in `RDFSource`

### DIFF
--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -67,10 +67,23 @@ module Ldp
     private
 
     ##
+    # @note tries to avoid doing a large scale copy of the {RDF::Repository}
+    #   data structure by using the existing {Ldp::Response#graph} if
+    #   {#graph_class} is {RDF::Graph}. otherwise, it tries to instantiate a
+    #   new graph projected over the same underlying {RDF::Graph#data}. finally,
+    #   if {#graph_class}'s initailizer doesn't accept a `data:` parameter, it
+    #   shovels {Ldp::Response#graph} into a new object of that class.
+    #
     # @param [Faraday::Response] graph query response
     # @return [RDF::Graph]
     def response_as_graph(resp)
-      resp.graph
+      if graph_class == RDF::Graph
+        resp.graph
+      else
+        graph_class.new(data: resp.graph.data)
+      end
+    rescue ArgumentError
+      build_empty_graph << resp.graph
     end
 
     ##

--- a/spec/lib/ldp/resource/rdf_source_spec.rb
+++ b/spec/lib/ldp/resource/rdf_source_spec.rb
@@ -148,5 +148,14 @@ describe Ldp::Resource::RdfSource do
     it "should use the specified class" do
       expect(subject.graph).to be_a SpecialGraph
     end
+
+    context "with a response body" do
+      subject { SpecialResource.new mock_client, "http://my.ldp.server/existing_object" }
+
+
+      it "should use the specified class" do
+        expect(subject.graph).to be_a SpecialGraph
+      end
+    end
   end
 end


### PR DESCRIPTION
this fix tries to retain the memory optimazitons of past changes, if possible.

ideally, all callers to this would pass an object that conforms to
`RDF::Graph`'s initializer interface, but it's probably too much to ask, so fall
back on a brute force method if needed.