### PR TITLE
yield to ActiveFedora's intrusive overrides

### DIFF
--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -77,12 +77,6 @@ module Ldp
     # @param [Faraday::Response] graph query response
     # @return [RDF::Graph]
     def response_as_graph(resp)
-      if graph_class == RDF::Graph
-        resp.graph
-      else
-        graph_class.new(data: resp.graph.data)
-      end
-    rescue ArgumentError
       build_empty_graph << resp.graph
     end
 


### PR DESCRIPTION
ActiveFedora uses a very specific override of `build_empty_graph`, and treats
the contract here as "will always call #build_empty_graph". it's a bit awkward,
but i think we need to give into it since AF is our primary user.