### PR TITLE
Fix URI.decode obsoletes in LDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/version_tmp
 tmp
 .storage
 /spec/examples.txt
+vendor
+.*.swp

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 # gem 'slop', '~> 3.6' if RUBY_PLATFORM == "java"
 gem 'byebug', platforms: [:mri]
-gem 'activesupport'
+gem 'activesupport', '< 7.0'
 gem 'capybara_discoball', '~> 0.0.2'
 gem 'derby',              '~> 1.0'
 

--- a/ldp.gemspec
+++ b/ldp.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "addressable"
   spec.add_dependency "faraday"
   spec.add_dependency "rdf",            ">= 1.1"
   spec.add_dependency "rdf-turtle"

--- a/lib/ldp.rb
+++ b/lib/ldp.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require 'ldp/version'
 require 'rdf/turtle'
 require 'json/ld'

--- a/lib/ldp/response.rb
+++ b/lib/ldp/response.rb
@@ -193,7 +193,7 @@ module Ldp
 
     def content_disposition_filename
       filename = content_disposition_attributes['filename']
-      Addressable::URI.escape(filename) if filename
+      Addressable::URI.unescape(filename) if filename
     end
 
     private

--- a/lib/ldp/response.rb
+++ b/lib/ldp/response.rb
@@ -193,7 +193,7 @@ module Ldp
 
     def content_disposition_filename
       filename = content_disposition_attributes['filename']
-      URI.decode(filename) if filename
+      Addressable::URI.escape(filename) if filename
     end
 
     private

--- a/spec/lib/ldp/response_spec.rb
+++ b/spec/lib/ldp/response_spec.rb
@@ -197,18 +197,37 @@ describe Ldp::Response do
   end
 
   describe '#content_disposition_filename' do
-    before do
-      allow(mock_response).to receive(:headers).and_return(
+    let(:headers) do
+      [
         { 'Content-Disposition' => 'filename="xyz.txt";' },
         { 'Content-Disposition' => 'attachment; filename=xyz.txt' },
-        { 'Content-Disposition' => 'attachment; filename="xyz.txt"; size="12345"' },
-        { 'Content-Disposition' => 'attachment; filename=""; size="12345"' },
-      )
+        { 'Content-Disposition' => 'attachment; filename="xyz.txt"; size="12345"' }
+      ]
+    end
+
+    before do
+      allow(mock_response).to receive(:headers).and_return(*headers)
     end
 
     it 'provides the filename from the content disposition header' do
       3.times { expect(subject.content_disposition_filename).to eq 'xyz.txt' }
-      expect(subject.content_disposition_filename).to eq ''
+    end
+
+    context 'with empty filename' do
+      let(:headers) { [{ 'Content-Disposition' => 'attachment; filename=""; size="12345"' }] }
+
+      it 'provides the filename from the content disposition header' do
+        expect(subject.content_disposition_filename).to eq ''
+      end
+    end
+
+    context 'with encoded filename' do
+      let(:headers) { [{ 'Content-Disposition' => 'attachment; filename="file%20with%20spaces.txt"; size="12345"' }] }
+
+      it 'provides the filename from the content disposition header' do
+        expect(subject.content_disposition_filename).to eq 'file with spaces.txt'
+      end
     end
   end
+
 end


### PR DESCRIPTION
Fix URI.decode obsolete warning