### PR TITLE
Update CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  samvera: samvera/circleci-orb@0
+  samvera: samvera/circleci-orb@1.0
 jobs:
   bundle_and_test:
     parameters:
@@ -36,10 +36,9 @@ jobs:
             fi
             [[ -z "$(git branch --all --list master */master)" ]]
 
-      - samvera/bundle_for_gem:
+      - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
-          project: ldp
 
       - samvera/rubocop
 
@@ -50,45 +49,45 @@ workflows:
     jobs:
       - bundle_and_test:
           name: ruby2-7_rails6-0
-          ruby_version: 2.7.0
-          rails_version: 6.0.2
+          ruby_version: 2.7.5
+          rails_version: 6.0.4.4
       - bundle_and_test:
           name: ruby2-6_rails6-0
-          ruby_version: 2.6.5
-          rails_version: 6.0.2
+          ruby_version: 2.6.9
+          rails_version: 6.0.4.4
       - bundle_and_test:
           name: ruby2-5_rails6-0
-          ruby_version: 2.5.7
-          rails_version: 6.0.2
+          ruby_version: 2.5.9
+          rails_version: 6.0.4.4
       - bundle_and_test:
           name: ruby2-7_rails5-2
-          ruby_version: 2.7.0
-          rails_version: 5.2.4
+          ruby_version: 2.7.5
+          rails_version: 5.2.6
       - bundle_and_test:
           name: ruby2-6_rails5-2
-          ruby_version: 2.6.5
-          rails_version: 5.2.4
+          ruby_version: 2.6.9
+          rails_version: 5.2.6
       - bundle_and_test:
           name: ruby2-5_rails5-2
-          ruby_version: 2.5.7
-          rails_version: 5.2.4
+          ruby_version: 2.5.9
+          rails_version: 5.2.6
       - bundle_and_test:
           name: ruby2-4_rails5-2
-          ruby_version: 2.4.6
-          rails_version: 5.2.4
+          ruby_version: 2.4.10
+          rails_version: 5.2.6
       - bundle_and_test:
           name: ruby2-7_rails5-1
-          ruby_version: 2.7.0
+          ruby_version: 2.7.5
           rails_version: 5.1.7
       - bundle_and_test:
           name: ruby2-6_rails5-1
-          ruby_version: 2.6.5
+          ruby_version: 2.6.9
           rails_version: 5.1.7
       - bundle_and_test:
           name: ruby2-5_rails5-1
-          ruby_version: 2.5.7
+          ruby_version: 2.5.9
           rails_version: 5.1.7
       - bundle_and_test:
           name: ruby2-4_rails5-1
-          ruby_version: 2.4.6
+          ruby_version: 2.4.10
           rails_version: 5.1.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,6 @@ workflows:
           ruby_version: 2.5.9
           rails_version: 5.2.6
       - bundle_and_test:
-          name: ruby2-4_rails5-2
-          ruby_version: 2.4.10
-          rails_version: 5.2.6
-      - bundle_and_test:
           name: ruby2-7_rails5-1
           ruby_version: 2.7.5
           rails_version: 5.1.7
@@ -86,8 +82,4 @@ workflows:
       - bundle_and_test:
           name: ruby2-5_rails5-1
           ruby_version: 2.5.9
-          rails_version: 5.1.7
-      - bundle_and_test:
-          name: ruby2-4_rails5-1
-          ruby_version: 2.4.10
           rails_version: 5.1.7


### PR DESCRIPTION
Use 1.0 version of samvera orb
Bump versions of ruby to get newer container images (bullseye vs. buster)
Bump versions of rails to newest in release series