### PR TITLE
Upgrade to coveralls-reborn

### DIFF
--- a/ldp.gemspec
+++ b/ldp.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "coveralls_reborn", "~> 0.24.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency 'bixby', '~> 3.0.0'


### PR DESCRIPTION
It is a maintained fork of ruby coveralls, and this will allow us to
update dependencies.