### PR TITLE
Support ruby 3.0 and 3.1, rails 7.0 releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,46 +48,37 @@ jobs:
 workflows:
   ci:
     jobs:
+      # Rails 6.1
+      - bundle_and_test:
+          name: ruby3-0_rails6-1
+          ruby_version: 3.0.4
+          rails_version: 6.1.6.1
       - bundle_and_test:
           name: ruby2-7_rails6-1
           ruby_version: 2.7.5
           rails_version: 6.1.6.1
+      # Rails 6.0
+      - bundle_and_test:
+          name: ruby3-0_rails6-0
+          ruby_version: 3.0.4
+          rails_version: 6.0.5
       - bundle_and_test:
           name: ruby2-7_rails6-0
           ruby_version: 2.7.5
           rails_version: 6.0.4.4
       - bundle_and_test:
-          name: ruby2-6_rails6-0
-          ruby_version: 2.6.9
-          rails_version: 6.0.4.4
+          name: ruby2-7_rails6-0
+          ruby_version: 2.7.6
+          rails_version: 6.0.5
+      # Rails 5.2
       - bundle_and_test:
-          name: ruby2-5_rails6-0
-          ruby_version: 2.5.9
-          rails_version: 6.0.4.4
+          name: ruby3-0_rails5-2
+          ruby_version: 3.0.4
+          rails_version: 5.2.8
       - bundle_and_test:
           name: ruby2-7_rails5-2
-          ruby_version: 2.7.5
-          rails_version: 5.2.6
-      - bundle_and_test:
-          name: ruby2-6_rails5-2
-          ruby_version: 2.6.9
-          rails_version: 5.2.6
-      - bundle_and_test:
-          name: ruby2-5_rails5-2
-          ruby_version: 2.5.9
-          rails_version: 5.2.6
-      - bundle_and_test:
-          name: ruby2-7_rails5-1
-          ruby_version: 2.7.5
-          rails_version: 5.1.7
-      - bundle_and_test:
-          name: ruby2-6_rails5-1
-          ruby_version: 2.6.9
-          rails_version: 5.1.7
-      - bundle_and_test:
-          name: ruby2-5_rails5-1
-          ruby_version: 2.5.9
-          rails_version: 5.1.7
+          ruby_version: 2.7.6
+          rails_version: 5.2.8
 
   nightly:
     triggers:
@@ -97,46 +88,36 @@ workflows:
             branches:
               only:
                 - main
+
     jobs:
+      # Rails 6.1
+      - bundle_and_test:
+          name: ruby3-0_rails6-1
+          ruby_version: 3.0.4
+          rails_version: 6.1.6.1
       - bundle_and_test:
           name: ruby2-7_rails6-1
           ruby_version: 2.7.5
           rails_version: 6.1.6.1
+      # Rails 6.0
+      - bundle_and_test:
+          name: ruby3-0_rails6-0
+          ruby_version: 3.0.4
+          rails_version: 6.0.5
       - bundle_and_test:
           name: ruby2-7_rails6-0
           ruby_version: 2.7.5
           rails_version: 6.0.4.4
       - bundle_and_test:
-          name: ruby2-6_rails6-0
-          ruby_version: 2.6.9
-          rails_version: 6.0.4.4
+          name: ruby2-7_rails6-0
+          ruby_version: 2.7.6
+          rails_version: 6.0.5
+      # Rails 5.2
       - bundle_and_test:
-          name: ruby2-5_rails6-0
-          ruby_version: 2.5.9
-          rails_version: 6.0.4.4
+          name: ruby3-0_rails5-2
+          ruby_version: 3.0.4
+          rails_version: 5.2.8
       - bundle_and_test:
           name: ruby2-7_rails5-2
-          ruby_version: 2.7.5
-          rails_version: 5.2.6
-      - bundle_and_test:
-          name: ruby2-6_rails5-2
-          ruby_version: 2.6.9
-          rails_version: 5.2.6
-      - bundle_and_test:
-          name: ruby2-5_rails5-2
-          ruby_version: 2.5.9
-          rails_version: 5.2.6
-      - bundle_and_test:
-          name: ruby2-7_rails5-1
-          ruby_version: 2.7.5
-          rails_version: 5.1.7
-      - bundle_and_test:
-          name: ruby2-6_rails5-1
-          ruby_version: 2.6.9
-          rails_version: 5.1.7
-      - bundle_and_test:
-          name: ruby2-5_rails5-1
-          ruby_version: 2.5.9
-          rails_version: 5.1.7
-
-
+          ruby_version: 2.7.6
+          rails_version: 5.2.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,35 +50,39 @@ workflows:
     jobs:
       # Rails 6.1
       - bundle_and_test:
+          name: ruby3-1_rails6-1
+          ruby_version: 3.1.3
+          rails_version: 6.1.7
+      - bundle_and_test:
           name: ruby3-0_rails6-1
-          ruby_version: 3.0.4
-          rails_version: 6.1.6.1
+          ruby_version: 3.0.5
+          rails_version: 6.1.7
       - bundle_and_test:
           name: ruby2-7_rails6-1
-          ruby_version: 2.7.5
-          rails_version: 6.1.6.1
+          ruby_version: 2.7.7
+          rails_version: 6.1.7
       # Rails 6.0
       - bundle_and_test:
+          name: ruby3-1_rails6-0
+          ruby_version: 3.1.3
+          rails_version: 6.0.6
+      - bundle_and_test:
           name: ruby3-0_rails6-0
-          ruby_version: 3.0.4
-          rails_version: 6.0.5
+          ruby_version: 3.0.5
+          rails_version: 6.0.6
       - bundle_and_test:
           name: ruby2-7_rails6-0
-          ruby_version: 2.7.5
-          rails_version: 6.0.4.4
-      - bundle_and_test:
-          name: ruby2-7_rails6-0
-          ruby_version: 2.7.6
-          rails_version: 6.0.5
+          ruby_version: 2.7.7
+          rails_version: 6.0.6
       # Rails 5.2
       - bundle_and_test:
           name: ruby3-0_rails5-2
-          ruby_version: 3.0.4
-          rails_version: 5.2.8
+          ruby_version: 3.0.5
+          rails_version: 5.2.8.1
       - bundle_and_test:
           name: ruby2-7_rails5-2
-          ruby_version: 2.7.6
-          rails_version: 5.2.8
+          ruby_version: 2.7.7
+          rails_version: 5.2.8.1
 
   nightly:
     triggers:
@@ -92,32 +96,36 @@ workflows:
     jobs:
       # Rails 6.1
       - bundle_and_test:
+          name: ruby3-1_rails6-1
+          ruby_version: 3.1.3
+          rails_version: 6.1.7
+      - bundle_and_test:
           name: ruby3-0_rails6-1
-          ruby_version: 3.0.4
-          rails_version: 6.1.6.1
+          ruby_version: 3.0.5
+          rails_version: 6.1.7
       - bundle_and_test:
           name: ruby2-7_rails6-1
-          ruby_version: 2.7.5
-          rails_version: 6.1.6.1
+          ruby_version: 2.7.7
+          rails_version: 6.1.7
       # Rails 6.0
       - bundle_and_test:
+          name: ruby3-1_rails6-0
+          ruby_version: 3.1.3
+          rails_version: 6.0.6
+      - bundle_and_test:
           name: ruby3-0_rails6-0
-          ruby_version: 3.0.4
-          rails_version: 6.0.5
+          ruby_version: 3.0.5
+          rails_version: 6.0.6
       - bundle_and_test:
           name: ruby2-7_rails6-0
-          ruby_version: 2.7.5
-          rails_version: 6.0.4.4
-      - bundle_and_test:
-          name: ruby2-7_rails6-0
-          ruby_version: 2.7.6
-          rails_version: 6.0.5
+          ruby_version: 2.7.7
+          rails_version: 6.0.6
       # Rails 5.2
       - bundle_and_test:
           name: ruby3-0_rails5-2
-          ruby_version: 3.0.4
-          rails_version: 5.2.8
+          ruby_version: 3.0.5
+          rails_version: 5.2.8.1
       - bundle_and_test:
           name: ruby2-7_rails5-2
-          ruby_version: 2.7.6
-          rails_version: 5.2.8
+          ruby_version: 2.7.7
+          rails_version: 5.2.8.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,19 @@ jobs:
 workflows:
   ci:
     jobs:
+      # Rails 7.0
+      - bundle_and_test:
+          name: ruby3-1_rails7-0
+          ruby_version: 3.1.3
+          rails_version: 7.0.4
+      - bundle_and_test:
+          name: ruby3-0_rails7-0
+          ruby_version: 3.0.5
+          rails_version: 7.0.4
+      - bundle_and_test:
+          name: ruby2-7_rails7-0
+          ruby_version: 2.7.7
+          rails_version: 7.0.4
       # Rails 6.1
       - bundle_and_test:
           name: ruby3-1_rails6-1
@@ -94,6 +107,19 @@ workflows:
                 - main
 
     jobs:
+      # Rails 7.0
+      - bundle_and_test:
+          name: ruby3-1_rails7-0
+          ruby_version: 3.1.3
+          rails_version: 7.0.4
+      - bundle_and_test:
+          name: ruby3-0_rails7-0
+          ruby_version: 3.0.5
+          rails_version: 7.0.4
+      - bundle_and_test:
+          name: ruby2-7_rails7-0
+          ruby_version: 2.7.7
+          rails_version: 7.0.4
       # Rails 6.1
       - bundle_and_test:
           name: ruby3-1_rails6-1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,10 @@ Bundler/DuplicatedGem:
   Exclude:
     - 'Gemfile'
 
+Metrics/AbcSize:
+  Exclude:
+    - 'lib/ldp/client/methods.rb'
+
 Metrics/BlockLength:
   Exclude:
     - ldp.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,8 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in ldp-client.gemspec
-gemspec
-
-# gem 'slop', '~> 3.6' if RUBY_PLATFORM == "java"
-gem 'byebug', platforms: [:mri]
 gem 'activesupport'
-gem 'capybara_discoball', '~> 0.0.2'
-gem 'derby',              '~> 1.0'
+gem 'byebug', platforms: [:mri]
+gem 'derby', git: 'https://github.com/samvera-labs/derby.git', branch: 'upgrade-rdf'
 
 if ENV['RAILS_VERSION']
   if ENV['RAILS_VERSION'] == 'edge'
@@ -16,3 +11,6 @@ if ENV['RAILS_VERSION']
     gem 'rails', ENV['RAILS_VERSION']
   end
 end
+
+# Specify your gem's dependencies in ldp-client.gemspec
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'activesupport'
 gem 'byebug', platforms: [:mri]
-gem 'derby', git: 'https://github.com/samvera-labs/derby.git', branch: 'upgrade-rdf'
 
 if ENV['RAILS_VERSION']
   if ENV['RAILS_VERSION'] == 'edge'

--- a/ldp.gemspec
+++ b/ldp.gemspec
@@ -10,30 +10,37 @@ Gem::Specification.new do |spec|
   spec.email         = ["chris@cbeer.info"]
   spec.description   = %q{Linked Data Platform client library}
   spec.summary       = spec.description
-  spec.homepage      = "https://github.com/projecthydra/ldp"
+  spec.homepage      = "https://github.com/samvera/ldp"
   spec.license       = "APACHE2"
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", '>= 1'
-  spec.add_dependency "rdf",            ">= 1.1"
-  spec.add_dependency "rdf-turtle"
-  spec.add_dependency "rdf-vocab",      ">= 0.8"
-  spec.add_dependency "rdf-isomorphic"
-  spec.add_dependency "json-ld"
-  spec.add_dependency "http_logger"
   spec.add_dependency "deprecation"
+  spec.add_dependency "faraday", '>= 1'
+  spec.add_dependency "http_logger"
+  spec.add_dependency "json-ld", "3.2.1"
+  spec.add_dependency "rdf", "3.2.1"
+  spec.add_dependency "rdf-isomorphic"
+  spec.add_dependency "rdf-ldp"
+  spec.add_dependency "rdf-turtle"
+  spec.add_dependency "rdf-vocab", ">= 0.8"
   spec.add_dependency "slop"
+
+  spec.add_development_dependency 'bixby'
   spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency 'capybara_discoball'
+  spec.add_development_dependency "coveralls_reborn"
+  spec.add_development_dependency 'github_changelog_generator'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "coveralls_reborn", "~> 0.24.0"
-  spec.add_development_dependency "simplecov"
   spec.add_development_dependency "rspec_junit_formatter"
-  spec.add_development_dependency 'bixby', '~> 3.0.0'
-  spec.add_development_dependency 'github_changelog_generator'
+  spec.add_development_dependency "rubocop-rake"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webrick"
 end

--- a/ldp.gemspec
+++ b/ldp.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "deprecation"
   spec.add_dependency "faraday", '>= 1'
   spec.add_dependency "http_logger"
-  spec.add_dependency "json-ld", "3.2.1"
-  spec.add_dependency "rdf", "3.2.1"
+  spec.add_dependency "json-ld", "~> 3.2"
+  spec.add_dependency "rdf", "~> 3.2"
   spec.add_dependency "rdf-isomorphic"
   spec.add_dependency "rdf-ldp"
   spec.add_dependency "rdf-turtle"

--- a/lib/ldp.rb
+++ b/lib/ldp.rb
@@ -1,11 +1,13 @@
 require 'ldp/version'
-require 'rdf/turtle'
-require 'json/ld'
-require 'rdf/isomorphic'
-require 'rdf/vocab/ldp'
-require 'logger'
-require 'singleton'
+
+require 'active_support'
 require 'deprecation'
+require 'json/ld'
+require 'logger'
+require 'rdf/isomorphic'
+require 'rdf/turtle'
+require 'rdf/vocab/ldp'
+require 'singleton'
 
 module Ldp
   RDF::Graph.send(:include, RDF::Isomorphic)

--- a/lib/ldp/client/methods.rb
+++ b/lib/ldp/client/methods.rb
@@ -10,6 +10,7 @@ module Ldp::Client::Methods
     else
       @http = Faraday.new *http_client
     end
+    yield @http if block_given?
   end
 
   def head url

--- a/lib/ldp/orm.rb
+++ b/lib/ldp/orm.rb
@@ -26,7 +26,7 @@ module Ldp
     end
 
     def value predicate
-      graph.query(:subject => subject_uri, :predicate => predicate).map do |stmt|
+      graph.query([subject_uri, predicate, nil]).map do |stmt|
         stmt.object
       end
     end

--- a/lib/ldp/resource/rdf_source.rb
+++ b/lib/ldp/resource/rdf_source.rb
@@ -8,8 +8,11 @@ module Ldp
       when RDF::Enumerable
         @graph = graph_or_response
       when Ldp::Response
+        # no-op
+        nil
       when NilClass
-      # nop
+        # no-op
+        nil
       else
         raise ArgumentError, "Third argument to #{self.class}.new should be a RDF::Enumerable or a Ldp::Response. You provided #{graph_or_response.class}"
       end
@@ -84,10 +87,10 @@ module Ldp
     # @param [RDF::Graph] original_graph The graph returned by the LDP server
     # @return [RDF::Graph] A graph stripped of any inlined resources present in the original
     def filtered_graph(original_graph)
-      contains_statements = original_graph.query(predicate: RDF::Vocab::LDP.contains)
+      contains_statements = original_graph.query([nil, RDF::Vocab::LDP.contains, nil])
 
       contains_statements.each_object do |contained_uri|
-        original_graph.delete(original_graph.query(subject: contained_uri))
+        original_graph.delete(original_graph.query([contained_uri, nil, nil]))
       end
 
       original_graph

--- a/lib/ldp/response.rb
+++ b/lib/ldp/response.rb
@@ -104,9 +104,7 @@ module Ldp
     ##
     # Get the graph for the resource (or a blank graph if there is no metadata for the resource)
     def graph
-      @graph ||= begin
-        RDF::Graph.new << reader
-      end
+      @graph ||= RDF::Graph.new << reader
     end
 
     def reader(&block)
@@ -193,7 +191,7 @@ module Ldp
 
     def content_disposition_filename
       filename = content_disposition_attributes['filename']
-      URI.decode(filename) if filename
+      CGI.unescape(filename) if filename
     end
 
     private

--- a/spec/lib/integration/integration_spec.rb
+++ b/spec/lib/integration/integration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 require 'capybara_discoball'
-require 'derby/server'
+require 'lamprey'
 
 describe 'Integration tests' do
   before(:all) do
@@ -12,20 +12,25 @@ describe 'Integration tests' do
     WebMock.enable!
   end
 
-  let!(:derby_server) do
-    Capybara::Discoball::Runner.new(Derby::Server).boot
+  let!(:ldp_server) do
+    Capybara::Discoball::Runner.new(RDF::Lamprey).boot
   end
 
   let(:debug) { ENV.fetch('DEBUG', false) }
 
   let(:client) do
-    Faraday.new(url: derby_server) do |faraday|
+    Faraday.new(url: ldp_server) do |faraday|
       faraday.response :logger if debug
       faraday.adapter Faraday.default_adapter
     end
   end
 
   subject { Ldp::Client.new client }
+
+  before do
+    # Initialize LDP server
+    subject.put "/", ""
+  end
 
   it 'creates resources' do
     subject.put '/rdf_source', ''

--- a/spec/lib/integration/integration_spec.rb
+++ b/spec/lib/integration/integration_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
+
 require 'capybara_discoball'
 require 'derby/server'
 
 describe 'Integration tests' do
+  before(:all) do
+    WebMock.disable!
+  end
+
+  after(:all) do
+    WebMock.enable!
+  end
+
   let!(:derby_server) do
     Capybara::Discoball::Runner.new(Derby::Server).boot
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,17 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-require 'simplecov'
 require 'coveralls'
+require 'pry-byebug'
+require 'rdf/vocab'
+require 'simplecov'
+require 'webmock/rspec'
 
-SimpleCov.formatter = 
-  SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::HTMLFormatter,
-                                           Coveralls::SimpleCov::Formatter])
-    
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+])
+
 SimpleCov.start do
   add_filter 'spec/'
 end


### PR DESCRIPTION
Rebase of #145 with additional commit to switch to Lamprey (rdf-ldp) as the LDP server used in integration tests.